### PR TITLE
Skip undef $file in _candidate_files

### DIFF
--- a/Next.pm
+++ b/Next.pm
@@ -482,6 +482,7 @@ sub _candidate_files {
     my $follow_symlinks = $parms->{follow_symlinks};
 
     for my $file ( grep { !exists $skip_dirs{$_} } readdir $dh ) {
+        next unless $file;
         my $fullpath = File::Spec->catdir( $dirname, $file );
         if ( !$follow_symlinks ) {
             next if -l $fullpath;


### PR DESCRIPTION
In some circumstances (like descending directory trees on SMB mounts), readdir $dh can return undef.  This causes unexpected behavior.